### PR TITLE
BACK-2589 Update enumcover to handle when name of constants change

### DIFF
--- a/enumcover.go
+++ b/enumcover.go
@@ -23,6 +23,11 @@ var Analyzer = &analysis.Analyzer{
 }
 var commentRegex = regexp.MustCompile(`enumcover:([\w\.]+)`)
 
+// Keep a map of renamed constants, where key => old name and value => new name
+var renamedConstants = map[string]string{
+	"Ptr": "Pointer",
+}
+
 func enumcoverCheck(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
 		commentMap := ast.NewCommentMap(pass.Fset, file, file.Comments)
@@ -91,7 +96,12 @@ func checkConsts(pass *analysis.Pass, n ast.Node, typeName string) {
 							}
 						}
 					}
+
 					namesForType[n.Name] = true
+					if renamedConstants[n.Name] != "" {
+						newName := renamedConstants[n.Name]
+						namesForType[newName] = true
+					}
 				}
 			}
 		}

--- a/testdata/src/stringenum/stringenum.go
+++ b/testdata/src/stringenum/stringenum.go
@@ -5,8 +5,11 @@ type MyEnum string
 const (
 	MyEnumA MyEnum = "a"
 	MyEnumB MyEnum = "b"
-	MyEnumC MyEnum = "c"
+	MyEnumD MyEnum = "c"
 )
+
+// MyEnumC is an alias for MyEnumD
+const MyEnumC = MyEnumD
 
 //enumcover:MyEnum
 var All = []MyEnum{MyEnumA, MyEnumB, MyEnumC}
@@ -15,7 +18,7 @@ var All = []MyEnum{MyEnumA, MyEnumB, MyEnumC}
 // MATCH:18 "Unhandled const: MyEnumC (c)"
 
 //enumcover:MyEnum
-var Some = []MyEnum{MyEnumA} // want `Unhandled const: MyEnumB \(b\)` `Unhandled const: MyEnumC \(c\)`
+var Some = []MyEnum{MyEnumA} // want `Unhandled const: MyEnumB \(b\)` `Unhandled const: MyEnumC \(c\)` `Unhandled const: MyEnumD \(c\)`
 
 //enumcover:MyEnum
 func HandleAll(e MyEnum) bool {
@@ -27,7 +30,7 @@ func HandleAll(e MyEnum) bool {
 }
 
 //enumcover:MyEnum
-func HandleSome(e MyEnum) bool { // want `Unhandled const: MyEnumC \(c\)`
+func HandleSome(e MyEnum) bool { // want `Unhandled const: MyEnumC \(c\)` `Unhandled const: MyEnumD \(c\)`
 	switch e {
 	case MyEnumA, MyEnumB:
 		return true
@@ -36,10 +39,28 @@ func HandleSome(e MyEnum) bool { // want `Unhandled const: MyEnumC \(c\)`
 }
 
 //enumcover:MyEnum
-func HandleSomeWithIfs(e MyEnum) bool { // want `Unhandled const: MyEnumC \(c\)`
+func HandleSomeWithIfs(e MyEnum) bool { // want `Unhandled const: MyEnumC \(c\)` `Unhandled const: MyEnumD \(c\)`
 	if e == MyEnumA {
 		return true
 	} else if e == MyEnumB {
+		return true
+	}
+	return false
+}
+
+//enumcover:MyEnum
+func HandleOneAlias(e MyEnum) bool {
+	switch e {
+	case MyEnumA, MyEnumB, MyEnumD:
+		return true
+	}
+	return false
+}
+
+//enumcover:MyEnum
+func HandleOldAliasName(e MyEnum) bool {
+	switch e {
+	case MyEnumA, MyEnumB, MyEnumC:
 		return true
 	}
 	return false


### PR DESCRIPTION
What changed?
Update enumcover to handle when name of a constant changes.
For instance, GO  1.18 renamed reflect.Ptr to reflect.Pointer. And this is breaking instances where enumcover directives is used on reflect.Kind. This was also failing enumcover tests where reflect.kind was used.

This PR is meant to fix that bug. And also fix this category of issues in the future, when names of Enums are aliased.
